### PR TITLE
changed up the left and center alignment

### DIFF
--- a/pages/matches.py
+++ b/pages/matches.py
@@ -15,26 +15,26 @@ def serve_layout():
         html.Button('Reload Graphs', id='refresh-page', style={"fontSize": 16, 'font-family': "Open Sans, verdana, arial, sans-serif"}),
         dmc.Space(h=20),
 
-        dmc.Text("Match Analytics", style={"fontSize": 28}, weight=500),
+        dmc.Text("Match Analytics", align="center", style={"fontSize": 28}, weight=500),
         dmc.Text("This section contains insights about the interactions (likes, matches, chats, and unmatches) you've "
                  "had on Hinge."),
         dmc.Space(h=20),
 
         # funnel graph showing breakdown of interactions
-        dmc.Text("Interaction Funnel", size="xl", align="center", weight=500),
+        dmc.Text("Interaction Funnel", size="xl", align="left", weight=500),
         dmc.Text("This funnel represents the funnel of your interactions with people on Hinge. The outermost layer "
                  "represents the total number of people you interacted with. Then it shows the number of outgoing likes "
-                 "you sent, matches received, and conversations started from those matches.", align="center"),
+                 "you sent, matches received, and conversations started from those matches.", align="left"),
         html.Div([
             dcc.Graph(id='live-update-graph'),
         ]),
 
         # side by side pie charts drilling into specifics of outgoing likes
-        dmc.Text("Outgoing Likes You've Sent", size="xl", align="center", weight=500),
+        dmc.Text("Outgoing Likes You've Sent", size="xl", align="left", weight=500),
         dmc.Text("This is a deep dive into your outgoing likes. The pie chart on the left shows a breakdown of the rare"
                  " cases where Hinge shows you a users you have already sent an outgoing like to vs the users you liked"
                  " once. The pie chart on the right shows how many outgoing likes you sent where you left a comment on the"
-                 " other person's profile.", align="center"),
+                 " other person's profile.", align="left"),
         html.Div(className='row', children=[
             html.Div(className='six columns', children=[
             dcc.Graph(id="live-update-double-likes-graph", style={'width': '50%', 'display': 'inline-block'}),
@@ -43,32 +43,32 @@ def serve_layout():
         ]),
 
         # table showing like comments
-        dmc.Text("What You're Commenting When You Like Someone's Content", size="xl", align="center", weight=500),
+        dmc.Text("What You're Commenting When You Like Someone's Content", size="xl", align="left", weight=500),
         html.Div([
             dash_table.DataTable(id='datatable-interactivity'),
             html.Div(id='datatable-interactivity-container'),
         ]),
 
         # line chart showing activity type frequencies by day
-        dmc.Text("Frequency of Action Types by Day", size="xl", align="center", weight=500),
+        dmc.Text("Frequency of Action Types by Day", size="xl", align="left", weight=500),
         dmc.Text("This line graph displays the counts of each action type (likes, matches, chats, and blocks aka unmatches)"
                  " per day over the duration of time you have been on Hinge. The legend on the right lists each of the"
                  " different action types, and you can select/ unselect different types to look at particular ones.",
-                 align="center"),
+                 align="left"),
         dcc.Graph("live-update-action_types-graph"),
 
         # pie chart showing percentage of interactions with a phone number share
-        dmc.Text("How Many People Did You Give Your Number To?", size="xl", align="center", weight=500),
+        dmc.Text("How Many People Did You Give Your Number To?", size="xl", align="left", weight=500),
         dmc.Text("This is the ratio of people you shared your phone number with out of the total number of people you "
                  "had chats with. This operates on the assumption you gave your phone number in a standard format, "
                  "ex: XXX-XXX-XXXX, XXXXXXXXXX, or (XXX)XXX-XXXX.",
-                 align="center"),
+                 align="left"),
         dcc.Graph("live-update-number_shares-graph"),
 
         # histogram showing the number of outgoing messages in each chat
-        dmc.Text("Outgoing Messages Sent per Chat", size="xl", align="center", weight=500),
+        dmc.Text("Outgoing Messages Sent per Chat", size="xl", align="left", weight=500),
         dmc.Text("This histogram shows the number of outgoing messages you sent in each chat.",
-                 align="center"),
+                 align="left"),
         dcc.Graph("live-update-messages-per-chat-graph"),
     ])
 

--- a/pages/user.py
+++ b/pages/user.py
@@ -12,15 +12,15 @@ layout = html.Div([
     html.Button('Reload Graphs', id='refresh-page',
                 style={"fontSize": 16, 'font-family': "Open Sans, verdana, arial, sans-serif"}),
     dmc.Space(h=20),
-    dmc.Text("User Analytics", style={"fontSize": 28}, weight=500),
+    dmc.Text("User Analytics", align="center", style={"fontSize": 28}, weight=500),
     dmc.Text("This section contains insights about your user data that was collected while you were using Hinge."),
     dmc.Space(h=20),
 
     # table showing account data
-    dmc.Text("User Account Info", size="xl", align="center", weight=500),
+    dmc.Text("User Account Info", size="xl", align="left", weight=500),
     dmc.Text("This table shows the account data that was collected while you were using Hinge. This includes data "
              "about when you downloaded the app, the last time you paused or unpaused the app, and the last time "
-             "you logged in.", align="center"),
+             "you logged in.", align="left"),
     dmc.Space(h=10),
     html.Div([
         dash_table.DataTable(id='datatable-interactivity'),
@@ -29,10 +29,10 @@ layout = html.Div([
 
     dmc.Space(h=20),
     # user latitude and longitude coordinates
-    dmc.Text("Where you've used the app", size="xl", align="center", weight=500),
+    dmc.Text("Where you've used the app", size="xl", align="left", weight=500),
     dmc.Text("This takes the public IP addresses from the sessions where you used Hinge and uses that to look up the "
              "latitude and longitude coordinates to show where you were when you were using the app. This is limited "
-             "to 100 sessions.", align="center"),
+             "to 100 sessions.", align="left"),
     # TODO: figure out what to do with this map because it's god awful to run
     dcc.Graph("live-update-coords-graph"),
 ])


### PR DESCRIPTION
## [Summary](https://github.com/users/smpotts/projects/2/views/1?pane=issue&itemId=70033758)
*Provide a brief summary of the changes in this PR and link to the relevant issue(s) if applicable.*

H1 titles would look better centered with H2 and text left aligned on the User and Match pages.

### Current Behavior
*Please describe the current behavior that you are modifying.*

Titles of the pages are left aligned and each graph title and text is centered

### New Behavior
*Please describe the behavior or changes that are being added by this PR.*

Titles are centered and all the rest of the text is left aligned

#### Does this new change introduce a breaking change?

- [ ] Yes
- [X] No


If this introduces a breaking change:
  1. Describe the impact on the application below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging.
  4. Create a ticket on the GitHub Project board to address the issue later.


### Other Information
*Any other information that is useful to note: visual changes, dependency changes, etc.*

