### PR TITLE
File name validation for match and user file uploads

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -4,7 +4,9 @@ import json
 
 
 def prepare_uploaded_match_data(file_path="../data/app_uploaded_files/matches.json"):
-    __validate_file_upload(file_path)
+    __validate_upload_file_type(file_path)
+    __validate_match_file_upload(file_path)
+
     with open(file_path, 'r') as file:
         # match upload data is a list of dictionaries
         match_upload_data = json.load(file)
@@ -131,12 +133,9 @@ def import_user_device_data(file_path="../data/app_uploaded_files/user.json"):
     return device_data
 
 
-def __validate_file_upload(file_path):
-    if not file_path.endswith('.json'):
-        raise ValueError("Invalid file type. Please upload a JSON file.")
-
-
 def __import_user_data_by_key(key, file_path):
+    __validate_upload_file_type(file_path)
+
     with open(file_path, 'r') as file:
         raw_user_data = json.load(file)
 
@@ -145,3 +144,13 @@ def __import_user_data_by_key(key, file_path):
         user_data = raw_user_data[key]
 
     return user_data
+
+
+def __validate_upload_file_type(file_path):
+    if not file_path.endswith('.json'):
+        raise ValueError("Invalid file type. Please upload a JSON file.")
+
+
+def __validate_match_file_upload(file_path):
+    if 'match' not in file_path:
+        raise ValueError("Invalid file name. Please upload a file with 'match' in the file name.")

--- a/analytics.py
+++ b/analytics.py
@@ -110,6 +110,16 @@ def phone_number_shares(events):
     return phone_number_share_ratios
 
 
+def import_user_account_data(file_path="../data/app_uploaded_files/user.json"):
+    account_data = __import_user_data_by_key("account", file_path)
+    return account_data
+
+
+def import_user_device_data(file_path="../data/app_uploaded_files/user.json"):
+    device_data = __import_user_data_by_key("devices", file_path)
+    return device_data
+
+
 def __build_comments_list(events):
     likes_w_comments = []
     like_events = events["like"].dropna()
@@ -123,18 +133,9 @@ def __build_comments_list(events):
     return likes_w_comments
 
 
-def import_user_account_data(file_path="../data/app_uploaded_files/user.json"):
-    account_data = __import_user_data_by_key("account", file_path)
-    return account_data
-
-
-def import_user_device_data(file_path="../data/app_uploaded_files/user.json"):
-    device_data = __import_user_data_by_key("devices", file_path)
-    return device_data
-
-
 def __import_user_data_by_key(key, file_path):
     __validate_upload_file_type(file_path)
+    __validate_user_file_upload(file_path)
 
     with open(file_path, 'r') as file:
         raw_user_data = json.load(file)
@@ -154,3 +155,8 @@ def __validate_upload_file_type(file_path):
 def __validate_match_file_upload(file_path):
     if 'match' not in file_path:
         raise ValueError("Invalid file name. Please upload a file with 'match' in the file name.")
+
+
+def __validate_user_file_upload(file_path):
+    if 'user' not in file_path:
+        raise ValueError("Invalid file name. Please upload a file with 'user' in the file name.")

--- a/tests/analytics_test.py
+++ b/tests/analytics_test.py
@@ -19,6 +19,10 @@ class AnalyticsTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             analytics.prepare_uploaded_match_data(USER_FILE_PATH)
 
+    def test_invalid_user_file_upload(self):
+        with self.assertRaises(ValueError):
+            analytics.import_user_account_data(MATCHES_FILE_PATH)
+
     def test_account_data_import(self):
         results = analytics.import_user_account_data(USER_FILE_PATH)
         self.assertEqual(len(results), 9) # 9 keys in the dictionary

--- a/tests/analytics_test.py
+++ b/tests/analytics_test.py
@@ -15,9 +15,17 @@ class AnalyticsTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             analytics.prepare_uploaded_match_data('tests/matches.csv')
 
+    def test_invalid_match_file_upload(self):
+        with self.assertRaises(ValueError):
+            analytics.prepare_uploaded_match_data(USER_FILE_PATH)
+
     def test_account_data_import(self):
         results = analytics.import_user_account_data(USER_FILE_PATH)
         self.assertEqual(len(results), 9) # 9 keys in the dictionary
+
+    def test_device_data_import(self):
+        results = analytics.import_user_device_data(USER_FILE_PATH)
+        self.assertEqual(len(results), 5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## [Summary](https://github.com/users/smpotts/projects/2/views/1?pane=issue&itemId=72408870)
*Provide a brief summary of the changes in this PR and link to the relevant issue(s) if applicable.*
At the moment there is no validation around the names of the files users are allowed to upload. There was at one point, but it was poorly organized any buggy so I removed it.


### Current Behavior
*Please describe the current behavior that you are modifying.*
The user can upload any file as long as it is a `.json` and the program will throw an error if it's not what it is expecting.

### New Behavior
*Please describe the behavior or changes that are being added by this PR.*
The upload process enforces some validation around the file names so that there has to be 'match' in the match file upload and 'user' in the user file upload.

#### Does this new change introduce a breaking change?

- [ ] Yes
- [X] No


If this introduces a breaking change:
  1. Describe the impact on the application below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging.
  4. Create a ticket on the GitHub Project board to address the issue later.


### Other Information
*Any other information that is useful to note: visual changes, dependency changes, etc.*

